### PR TITLE
[common] fix branchesLoader manifest not including subdirs

### DIFF
--- a/src/common/branchesLoader.js
+++ b/src/common/branchesLoader.js
@@ -254,18 +254,10 @@ const runBranchSetups = async () => {
 		}
 
 		// regenerate files and version
-		branches[b].files = glob.sync(`${cacheName}/*`);
+		const cacheGlob = `${cacheName}/**/*.*`;
+		branches[b].files = glob.sync(cacheGlob);
 
-		let fileHashes = [];
-
-		for (const f of glob.sync(`${cacheName}/**/*.*`)) {
-			const content = readFileSync(f);
-
-			const baseHash = sha256(content);
-
-			fileHashes.push(baseHash);
-		}
-
+		const fileHashes = branches[b].files.map((f) => sha256(readFileSync(f)));
 		branches[b].version = parseInt(
 			sha256(fileHashes.join(" ") + branches[b].patch + branches[b].preload).substring(0, 2),
 			16,


### PR DESCRIPTION
this PR slightly refactors the manifest generation code in `branchesLoader.js` so that it complies with updater v2 on windows.
currently, two seperate glob operations are used, one for the hash, and one for the actual files. the latter does not include subdirectories, causing updater v2 to reject the update.
i imagine this was not caught during testing as OpenAsar does not implement this check.