### PR TITLE
Add branch fail error handling

### DIFF
--- a/branches/mod/betterdiscord/meta.js
+++ b/branches/mod/betterdiscord/meta.js
@@ -10,6 +10,7 @@ export const incompatibilities = ["vencord", "equicord", "moonlight"];
 export async function setup(target, log) {
 	log("Downloading latest asar...");
 
+	throw new Error("Penis explosion error");
 	const url = await fetch("https://api.github.com/repos/BetterDiscord/BetterDiscord/releases/latest")
 		.then((r) => r.json())
 		.then((j) => j.assets.find((a) => a.browser_download_url?.includes(".asar")).browser_download_url);

--- a/branches/mod/betterdiscord/meta.js
+++ b/branches/mod/betterdiscord/meta.js
@@ -10,7 +10,6 @@ export const incompatibilities = ["vencord", "equicord", "moonlight"];
 export async function setup(target, log) {
 	log("Downloading latest asar...");
 
-	throw new Error("Penis explosion error");
 	const url = await fetch("https://api.github.com/repos/BetterDiscord/BetterDiscord/releases/latest")
 		.then((r) => r.json())
 		.then((j) => j.assets.find((a) => a.browser_download_url?.includes(".asar")).browser_download_url);

--- a/branches/mod/shelter/main.js
+++ b/branches/mod/shelter/main.js
@@ -191,7 +191,7 @@ function onSettings(settings) {
 		if (typeof ue2 === "string") {
 			const match = ue2.match(rg);
 			if (match?.[2]) {
-				settings.set("NEW_UPDATE_ENDPOINT", `${h}/${match[2]}`);
+				settings.set("NEW_UPDATE_ENDPOINT", `${h}/${match[2]}/`);
 			}
 		}
 	});

--- a/branches/mod/shelter/preload.js
+++ b/branches/mod/shelter/preload.js
@@ -47,16 +47,28 @@ ipcRenderer.invoke("SHELTER_BUNDLE_FETCH").then((bundle) => {
 */
 
 const branchesRaw = JSON.parse(fs.readFileSync(path.join(__dirname, "branches.json"), "utf8"));
-const branches = Object.fromEntries(
-	branchesRaw.map((branch) => [branch.name, { ...branch, name: branch.displayName, desc: branch.description }]),
-);
+const mapBranches = (list) =>
+	Object.fromEntries(
+		list.map((branch) => [branch.name, { ...branch, name: branch.displayName, desc: branch.description }]),
+	);
+const branches = mapBranches(branchesRaw);
 
 const readBranches = () => ipcRenderer.invoke("SHELTER_BRANCH_GET");
 
 const setBranches = (branches) => ipcRenderer.invoke("SHELTER_BRANCH_SET", branches);
 
 contextBridge.exposeInMainWorld("SheltupdateNative", {
-	getAvailableBranches: () => Promise.resolve(branches),
+	getAvailableBranches: async () => {
+		try {
+			const host = await ipcRenderer.invoke("SHELTER_HOST_GET");
+			const response = await fetch(`${host}/sheltupdate_branches`, { signal: AbortSignal.timeout(5_000) });
+			if (!response.ok) throw new Error(`HTTP ${response.status}`);
+			return mapBranches(await response.json());
+		} catch (error) {
+			console.warn("[sheltupdate] Could not fetch live branch status", error);
+			return branches;
+		}
+	},
 	getCurrentBranches: readBranches,
 
 	setBranches: async (br) => {

--- a/branches/mod/shelter/preload.js
+++ b/branches/mod/shelter/preload.js
@@ -51,7 +51,12 @@ const mapBranches = (list) =>
 	Object.fromEntries(
 		list.map((branch) => [branch.name, { ...branch, name: branch.displayName, desc: branch.description }]),
 	);
-const branches = mapBranches(branchesRaw);
+// this represents the snapshot from the server launch: new branches cannot be added or removed
+// at runtime
+const trustedBranches = mapBranches(branchesRaw);
+// this is the "weak" server state, which is used only for the UI to show branch status
+// security is more lax but it will get rejected from the native side if tampered with (mitm)
+let lastBranches = trustedBranches;
 
 const readBranches = () => ipcRenderer.invoke("SHELTER_BRANCH_GET");
 
@@ -63,10 +68,14 @@ contextBridge.exposeInMainWorld("SheltupdateNative", {
 			const host = await ipcRenderer.invoke("SHELTER_HOST_GET");
 			const response = await fetch(`${host}/sheltupdate_branches`, { signal: AbortSignal.timeout(5_000) });
 			if (!response.ok) throw new Error(`HTTP ${response.status}`);
-			return mapBranches(await response.json());
+			lastBranches = mapBranches(await response.json());
+			return lastBranches;
 		} catch (error) {
 			console.warn("[sheltupdate] Could not fetch live branch status", error);
-			return branches;
+			// set all branches to failing to indicate that something exploded
+			return Object.fromEntries(
+				Object.entries(lastBranches).map(([name, branch]) => [name, { ...branch, enabled: false }]),
+			);
 		}
 	},
 	getCurrentBranches: readBranches,
@@ -79,13 +88,13 @@ contextBridge.exposeInMainWorld("SheltupdateNative", {
 
 		// don't use `in` or `[]` as those are true for e.g. __proto__
 		for (const branch of br)
-			if (typeof branch !== "string" || !Object.keys(branches).includes(branch))
+			if (typeof branch !== "string" || !Object.keys(trustedBranches).includes(branch))
 				throw new Error("[sheltupdate] invalid branches passed to setBranches");
 
 		// get user permission first, this is our main privesc safeguard
 		const dialogState = await ipcRenderer.invoke(
 			"SHELTER_BRANCHCHANGE_SECURITY_DIALOG",
-			`Confirm that you want to change your installed mods to: ${br.map((b) => branches[b].name).join(", ")}?`,
+			`Confirm that you want to change your installed mods to: ${br.map((b) => trustedBranches[b].name).join(", ")}?`,
 		);
 
 		if (dialogState.response === 0)

--- a/branches/mod/shelter/selector-ui.js
+++ b/branches/mod/shelter/selector-ui.js
@@ -30,7 +30,7 @@
 	} = shelter;
 
 	const {
-		settings: { registerSection },
+		settings: { BadgeType, registerSection },
 	} = shelter.plugin.scoped;
 
 	const ClientModsIcon = html`
@@ -83,20 +83,32 @@
 		if (window.BdApi && !currentBranches().includes("betterdiscord")) setBdOtherwiseLoaded(true);
 	});
 
-	const updateAvailableBranches = () => SheltupdateNative.getAvailableBranches().then((branches) => {
-		// group by type, conveniently "mod" is before "tool" alphabetically
-		const grouped = {};
-		for (const branchName in branches) {
-			const data = branches[branchName];
-			if (!grouped[data.type]) grouped[data.type] = {};
+	let lastState;
+	const updateClientModsSection = (newState) => {
+		if (lastState === newState) return;
 
-			grouped[data.type][branchName] = data;
-		}
+		 lastState = newState;
+		 registerSection("section", "sheltupdate", "Client Mods", SettingsView, {
+			icon: ClientModsIcon,
+			badge: newState ? { type: BadgeType.WARNING } : undefined,
+		 });
+	};
 
-		setBranchMetaGrouped(grouped);
-		setBranchMetaRaw(branches);
-	});
-	updateAvailableBranches();
+	const updateAvailableBranches = () =>
+		SheltupdateNative.getAvailableBranches().then((branches) => {
+			// group by type, conveniently "mod" is before "tool" alphabetically
+			const grouped = {};
+			for (const branchName in branches) {
+				const data = branches[branchName];
+				if (!grouped[data.type]) grouped[data.type] = {};
+
+				grouped[data.type][branchName] = data;
+			}
+
+			setBranchMetaGrouped(grouped);
+			setBranchMetaRaw(branches);
+			updateClientModsSection(Object.values(branches).some((branch) => branch.enabled === false));
+		});
 
 	const prettyModNames = (branches) => {
 		const modNames = [...branches.filter((b) => b !== "shelter").map((b) => branchMetaRaw()[b].name)];
@@ -115,7 +127,8 @@
 	// ok so this will display *above* the shelter heading which is not ideal but its okay i guess
 	registerSection("divider");
 	registerSection("header", "Sheltupdate");
-	registerSection("section", "sheltupdate", "Client Mods", SettingsView, { icon: ClientModsIcon });
+	updateClientModsSection(false);
+	updateAvailableBranches();
 
 	function BranchEntry(props /*: { name, data, value, onChange } */) {
 		// note: if shelter is disabled (i.e. you uninstalled sheltupdate), allow switching back on
@@ -149,6 +162,8 @@
 
 	function SettingsView() {
 		updateAvailableBranches();
+		const updateTimer = setInterval(updateAvailableBranches, 10_000);
+		onCleanup(() => clearInterval(updateTimer));
 
 		// a Set<string> of branches
 		const [pendingBranches, setPendingBranches] = createSignal(new Set(currentBranches()));
@@ -186,7 +201,7 @@
 				       	}}>
 								<${Header} tag=${HeaderTags.HeadingMD} margin=${false}>Some branches are currently unavailable due to server-side failure.<//>
 								<div style=${{ "margin-top": "8px" }}/>
-								${() => failedBranches().map((branch) => html`<${Text}>• ${branch.displayName}</${Text}>`)}
+								${() => failedBranches().map((branch) => html`<${Text}>• ${branch.displayName}</${Text}><br/>`)}
 						</div>
 						`
 						: null}

--- a/branches/mod/shelter/selector-ui.js
+++ b/branches/mod/shelter/selector-ui.js
@@ -185,9 +185,9 @@
 							 "margin-bottom": "12px"
 				       	}}>
 								<${Header} tag=${HeaderTags.HeadingMD} margin=${false}>Some branches are currently unavailable due to server-side failure.<//>
-								<div style=${{ "margin-top": "8px" }}>
+								<div style=${{ "margin-top": "8px" }}/>
 								${() => failedBranches().map((branch) => html`<${Text}>• ${branch.displayName}</${Text}>`)}
-							</div>
+						</div>
 						`
 						: null}
 

--- a/branches/mod/shelter/selector-ui.js
+++ b/branches/mod/shelter/selector-ui.js
@@ -50,6 +50,7 @@
 
 	const [branchMetaRaw, setBranchMetaRaw] = createSignal();
 	const [branchMetaGrouped, setBranchMetaGrouped] = createSignal();
+	const failedBranches = () => Object.values(branchMetaRaw() ?? {}).filter((branch) => branch.enabled === false);
 	const [currentBranches, setCurrentBranches] = createSignal();
 
 	const [currentHost, setCurrentHost] = createSignal();
@@ -59,6 +60,16 @@
 
 	const [vencordOtherwiseLoaded, setVencordOtherwiseLoaded] = createSignal(false);
 	const [bdOtherwiseLoaded, setBdOtherwiseLoaded] = createSignal(false);
+
+	const showErrorToast = (title, error) => {
+		console.error(`[sheltupdate] ${title}`, error);
+		showToast({
+			title,
+			color: ToastColors.CRITICAL,
+			content: "The change could not be applied.",
+			duration: 5000,
+		});
+	};
 
 	const updateCurrent = () =>
 		Promise.all([
@@ -72,7 +83,7 @@
 		if (window.BdApi && !currentBranches().includes("betterdiscord")) setBdOtherwiseLoaded(true);
 	});
 
-	SheltupdateNative.getAvailableBranches().then((branches) => {
+	const updateAvailableBranches = () => SheltupdateNative.getAvailableBranches().then((branches) => {
 		// group by type, conveniently "mod" is before "tool" alphabetically
 		const grouped = {};
 		for (const branchName in branches) {
@@ -85,6 +96,7 @@
 		setBranchMetaGrouped(grouped);
 		setBranchMetaRaw(branches);
 	});
+	updateAvailableBranches();
 
 	const prettyModNames = (branches) => {
 		const modNames = [...branches.filter((b) => b !== "shelter").map((b) => branchMetaRaw()[b].name)];
@@ -108,6 +120,9 @@
 	function BranchEntry(props /*: { name, data, value, onChange } */) {
 		// note: if shelter is disabled (i.e. you uninstalled sheltupdate), allow switching back on
 		const disabled = () => {
+			if (props.data.enabled === false && !props.value) {
+				return "This branch is temporarily unavailable due to a server-side error.";
+			}
 			if (props.name === "shelter" && props.value) {
 				return "You need shelter to have access to this menu. Try uninstalling sheltupdate.";
 			}
@@ -133,6 +148,8 @@
 	}
 
 	function SettingsView() {
+		updateAvailableBranches();
+
 		// a Set<string> of branches
 		const [pendingBranches, setPendingBranches] = createSignal(new Set(currentBranches()));
 
@@ -152,6 +169,27 @@
 
 			return html`
 			  <${Header} tag=${HeaderTags.H1} style="margin-bottom: 1rem">Client Mod Settings<//>
+
+				${() =>
+					failedBranches().length
+						? html`
+							<div style=${{
+						    "box-sizing": "border-box",
+						    "padding": "16px",
+						    "color": "var(--text-muted)",
+						    "width": "100%",
+						    "border-radius": "8px",
+						    "background": "var(--background-feedback-warning)",
+						    "border": "1px solid var(--border-feedback-warning)",
+						    "margin-top": "12px",
+							 "margin-bottom": "12px"
+				       	}}>
+								<${Header} tag=${HeaderTags.HeadingMD} margin=${false}>Some branches are currently unavailable due to server-side failure.<//>
+								<div style=${{ "margin-top": "8px" }}>
+								${() => failedBranches().map((branch) => html`<${Text}>• ${branch.displayName}</${Text}>`)}
+							</div>
+						`
+						: null}
 
 				<${Text}>
 					Your installation of ${() => prettyModNames(currentBranches())} is being managed by
@@ -211,12 +249,7 @@
 							setUninstallCache(currentBranches());
 							SheltupdateNative.uninstall().then(updateCurrent, (err) => {
 								updateCurrent();
-								showToast({
-									title: "Failed to change mods!",
-									color: ToastColors.CRITICAL,
-									content: err?.message ?? err,
-									duration: 5000,
-								});
+								showErrorToast("Failed to change mods!", err);
 							});
 						}}
 					  style=${{ "margin-left": "1rem" }}
@@ -243,12 +276,7 @@
 						},
 						(err) => {
 							updateCurrent();
-							showToast({
-								title: "Failed to change mods!",
-								color: ToastColors.CRITICAL,
-								content: err?.message ?? err,
-								duration: 5000,
-							});
+							showErrorToast("Failed to change mods!", err);
 						},
 					);
 				}}
@@ -282,12 +310,7 @@
 					onClick=${(e) =>
 						SheltupdateNative.setBranches(uninstallCache()).then(updateCurrent, (err) => {
 							updateCurrent();
-							showToast({
-								title: "Failed to change mods!",
-								color: ToastColors.CRITICAL,
-								content: err?.message ?? err,
-								duration: 5000,
-							});
+							showErrorToast("Failed to change mods!", err);
 						})}
 					style=${{ "margin-top": "2rem" }}
 				>
@@ -381,12 +404,7 @@
 						openHostChangeModal().then((v) =>
 							SheltupdateNative.setCurrentHost(v).then(updateCurrent, (err) => {
 								updateCurrent();
-								showToast({
-									title: "Failed to change host!",
-									color: ToastColors.CRITICAL,
-									content: err?.message ?? err,
-									duration: 5000,
-								});
+								showErrorToast("Failed to change host!", err);
 							}),
 						)}
 				>Change</Button>

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,8 @@
 	},
 	"stats": true,
 	"setupIntervalHours": 3,
+	"branchRetryMinSeconds": 30,
+	"branchRetryMaxSeconds": 3600,
 	"discovery": {
 		"enabled": false,
 		"name": "🇩🇪 DE",

--- a/src/common/branchManager.js
+++ b/src/common/branchManager.js
@@ -1,0 +1,85 @@
+import { config } from "./config.js";
+
+export class BranchManager {
+	#branches = new Map();
+
+	register(name, setup) {
+		if (this.#branches.has(name)) throw new Error(`Branch ${name} is already registered`);
+
+		this.#branches.set(name, {
+			setup,
+			enabled: !setup,
+			error: undefined,
+			failures: 0,
+			retryDelaySeconds: undefined,
+			retryAt: undefined,
+			inFlight: undefined,
+			timer: undefined,
+		});
+	}
+
+	isEnabled(names) {
+		return names.every((name) => this.#branches.get(name)?.enabled);
+	}
+
+	getStatus(name) {
+		const state = this.#branches.get(name);
+		if (!state) return undefined;
+
+		return {
+			enabled: state.enabled,
+			retryAt: state.retryAt,
+		};
+	}
+
+	async ensure(names) {
+		for (const name of names) {
+			const state = this.#branches.get(name);
+			if (!state) throw new Error(`Invalid branch requested: ${name}`);
+			if (state.inFlight) await state.inFlight;
+			if (!state.enabled) throw new Error(`Branch ${name} is disabled${state.error ? `: ${state.error}` : ""}`);
+		}
+	}
+
+	setup(name) {
+		const state = this.#branches.get(name);
+		if (!state) return Promise.reject(new Error(`Invalid branch requested: ${name}`));
+		if (!state.setup) return Promise.resolve(true);
+		if (state.inFlight) return state.inFlight;
+		if (state.retryAt && Date.now() < state.retryAt) return Promise.resolve(false);
+		clearTimeout(state.timer);
+
+		state.inFlight = Promise.resolve()
+			.then(state.setup)
+			.then(() => {
+				state.enabled = true;
+				state.error = undefined;
+				state.failures = 0;
+				state.retryDelaySeconds = undefined;
+				state.retryAt = undefined;
+				return true;
+			})
+			.catch((error) => {
+				state.error = error instanceof Error ? error.message : String(error);
+				state.failures++;
+				if (state.retryDelaySeconds >= config.branchRetryMaxSeconds) state.enabled = false;
+
+				state.retryDelaySeconds = Math.min(
+					config.branchRetryMinSeconds * 2 ** (state.failures - 1),
+					config.branchRetryMaxSeconds,
+				);
+				const delay = state.retryDelaySeconds * 1000;
+				state.retryAt = Date.now() + delay;
+				state.timer = setTimeout(() => this.setup(name), delay);
+				state.timer.unref?.();
+				console.error(
+					`[sheltupdate] ${state.enabled ? "Keeping cached" : "Disabled"} branch ${name}; retrying in ${delay}ms`,
+					error,
+				);
+				return false;
+			})
+			.finally(() => (state.inFlight = undefined));
+
+		return state.inFlight;
+	}
+}

--- a/src/common/branchManager.js
+++ b/src/common/branchManager.js
@@ -1,4 +1,6 @@
 import { config } from "./config.js";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { section } from "./tracer.js";
 
 export class BranchManager {
 	#branches = new Map();
@@ -49,17 +51,17 @@ export class BranchManager {
 		if (state.retryAt && Date.now() < state.retryAt) return Promise.resolve(false);
 		clearTimeout(state.timer);
 
-		state.inFlight = Promise.resolve()
-			.then(state.setup)
-			.then(() => {
+		state.inFlight = section(`${name} setup`, async (span) => {
+			try {
+				await state.setup(span);
+
 				state.enabled = true;
 				state.error = undefined;
 				state.failures = 0;
 				state.retryDelaySeconds = undefined;
 				state.retryAt = undefined;
 				return true;
-			})
-			.catch((error) => {
+			} catch (error) {
 				state.error = error instanceof Error ? error.message : String(error);
 				state.failures++;
 				if (state.retryDelaySeconds >= config.branchRetryMaxSeconds) state.enabled = false;
@@ -72,13 +74,17 @@ export class BranchManager {
 				state.retryAt = Date.now() + delay;
 				state.timer = setTimeout(() => this.setup(name), delay);
 				state.timer.unref?.();
-				console.error(
-					`[sheltupdate] ${state.enabled ? "Keeping cached" : "Disabled"} branch ${name}; retrying in ${delay}ms`,
-					error,
-				);
+
+				span.setStatus({ code: SpanStatusCode.ERROR });
+				span.recordException(error);
+				span.addEvent(state.enabled ? "serving cached version" : "branch disabled", {
+					branch: name,
+					retryDelayMs: delay,
+					error: state.error,
+				});
 				return false;
-			})
-			.finally(() => (state.inFlight = undefined));
+			}
+		}).finally(() => (state.inFlight = undefined));
 
 		return state.inFlight;
 	}

--- a/src/common/branchesLoader.js
+++ b/src/common/branchesLoader.js
@@ -8,12 +8,12 @@ import { config, srcDir, version as shupVersion } from "./config.js";
 import { cacheRoot, createCacheTempDir } from "./cacheStores.js";
 import { dcVersion } from "../desktopCore/index.js";
 import { withSection, section } from "./tracer.js";
+import { BranchManager } from "./branchManager.js";
 
 let branches = {};
+const branchManager = new BranchManager();
 
 const orderingMap = new Map(); // string => number
-
-const setupPromises = new Map(); // string => [Promise, resolve(), boolean]
 
 const sha256 = (data) => createHash("sha256").update(data).digest("hex");
 
@@ -34,7 +34,10 @@ const sortBranchesInPlace = (b) => {
 	}
 };
 
-export const getBranch = (b) => branches[sortBranchesInPlace(b.split("+"))?.join("+")];
+export const getBranch = (b) => {
+	const names = sortBranchesInPlace(b.split("+"));
+	return names && branchManager.isEnabled(names) ? branches[names.join("+")] : undefined;
+};
 
 export const getSingleBranchMetas = () => {
 	const sbranches = Object.entries(branches).filter(([, b]) => b.type !== "mixed" && !b.hidden);
@@ -48,19 +51,13 @@ export const getSingleBranchMetas = () => {
 		description: b.description,
 		incompatibilities: b.incompatibilities,
 		hidden: b.hidden,
+		...branchManager.getStatus(n),
 	}));
 };
 
 // waits for any active setup to finish
 export const ensureBranchIsReady = withSection("wait for branch ready", async (span, br) => {
-	await Promise.all(
-		br.split("+").map((b) => {
-			const [promise, _, isSettingUp] = setupPromises.get(b);
-			if (isSettingUp) span.addEvent(`Having to wait for branch ${b} to set up...`);
-
-			return promise;
-		}),
-	);
+	await branchManager.ensure(br.split("+"));
 });
 
 const getBranchStaticCacheDir = (b) => join(branchCacheRoot, b, "static");
@@ -164,18 +161,10 @@ const init = withSection("branch finder", async (span) => {
 				description,
 				incompatibilities,
 				hidden,
-				setup,
 				staticCacheDir: cacheDir,
 			};
 
-			// create wait-for-setup promises
-			if (setup) {
-				let resolve;
-				const prom = new Promise((r) => (resolve = r));
-				setupPromises.set(name, [prom, resolve, false]);
-			} else {
-				setupPromises.set(name, [Promise.resolve(), () => {}, false]);
-			}
+			branchManager.register(name, setup && (() => setupBranch(name, setup)));
 		}
 	});
 
@@ -254,55 +243,34 @@ const init = withSection("branch finder", async (span) => {
 	});
 });
 
-const runBranchSetups = withSection("periodic branch setups", async (span) => {
-	// perfect for async code I guess
+const setupBranch = (name, setup) =>
+	section(`${name} setup`, async (span) => {
+		const setupDir = createCacheTempDir(`branch-${name}`);
+		try {
+			cpSync(branches[name].staticCacheDir, setupDir, { recursive: true });
+			await setup(setupDir, (...args) => span.addEvent(args.join(" ")));
 
-	await Promise.all(Object.keys(branches).map(singleSetup));
-
-	async function singleSetup(b) {
-		if (branches[b].type === "mixed" || !branches[b].setup) return;
-
-		await section(`${b} setup`, async (span) => {
-			const [_promise, resolve, isSettingUp, goAnyway] = setupPromises.get(b);
-			if (isSettingUp && !goAnyway) {
-				span.addEvent(`Skipped setting up ${b} as it was already being setup.`);
-				return;
-			}
-
-			let newResolve;
-			const newProm = new Promise((r) => (newResolve = r));
-			setupPromises.set(b, [newProm, newResolve, true]);
-
-			const setupDir = createCacheTempDir(`branch-${b}`);
-			try {
-				cpSync(branches[b].staticCacheDir, setupDir, { recursive: true });
-				await branches[b].setup(setupDir, (...a) => span.addEvent(a.join(" ")));
-			} catch (e) {
-				rmSync(setupDir, { recursive: true, force: true });
-				// we failed! leave it in a "setting up" state until next time.
-				setupPromises.set(b, [newProm, newResolve, true, true]);
-				throw e;
-			}
-
-			const cacheDir = replaceCacheDir(getBranchCurrentCacheDir(b), setupDir, `branch-${b}-old`);
-
-			// regenerate files and version
+			const cacheDir = replaceCacheDir(getBranchCurrentCacheDir(name), setupDir, `branch-${name}-old`);
 			const allFiles = glob.sync(`${cacheDir}/**/*.*`);
-			branches[b].cacheDirs = [cacheDir];
-			branches[b].files = allFiles;
+			branches[name].cacheDirs = [cacheDir];
+			branches[name].files = allFiles;
 
 			const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
-			branches[b].version = parseInt(
-				sha256(fileHashes.join(" ") + branches[b].main + branches[b].preload + dcVersion).substring(0, 2),
+			branches[name].version = parseInt(
+				sha256(fileHashes.join(" ") + branches[name].main + branches[name].preload + dcVersion).substring(0, 2),
 				16,
 			);
+		} catch (error) {
+			rmSync(setupDir, { recursive: true, force: true });
+			throw error;
+		}
+	});
 
-			setupPromises.set(b, [newProm, newResolve, false]);
-
-			resolve();
-			newResolve();
-		});
-	}
+const runBranchSetups = withSection("periodic branch setups", async () => {
+	const names = Object.entries(branches)
+		.filter(([, branch]) => branch.type !== "mixed")
+		.map(([name]) => name);
+	await Promise.all(names.map((name) => branchManager.setup(name)));
 });
 
 await init(); // lol top level await go BRRRRRRRRR

--- a/src/common/branchesLoader.js
+++ b/src/common/branchesLoader.js
@@ -164,7 +164,7 @@ const init = withSection("branch finder", async (span) => {
 				staticCacheDir: cacheDir,
 			};
 
-			branchManager.register(name, setup && (() => setupBranch(name, setup)));
+			branchManager.register(name, setup && ((span) => setupBranch(name, setup, span)));
 		}
 	});
 
@@ -243,28 +243,27 @@ const init = withSection("branch finder", async (span) => {
 	});
 });
 
-const setupBranch = (name, setup) =>
-	section(`${name} setup`, async (span) => {
-		const setupDir = createCacheTempDir(`branch-${name}`);
-		try {
-			cpSync(branches[name].staticCacheDir, setupDir, { recursive: true });
-			await setup(setupDir, (...args) => span.addEvent(args.join(" ")));
+const setupBranch = async (name, setup, span) => {
+	const setupDir = createCacheTempDir(`branch-${name}`);
+	try {
+		cpSync(branches[name].staticCacheDir, setupDir, { recursive: true });
+		await setup(setupDir, (...args) => span.addEvent(args.join(" ")));
 
-			const cacheDir = replaceCacheDir(getBranchCurrentCacheDir(name), setupDir, `branch-${name}-old`);
-			const allFiles = glob.sync(`${cacheDir}/**/*.*`);
-			branches[name].cacheDirs = [cacheDir];
-			branches[name].files = allFiles;
+		const cacheDir = replaceCacheDir(getBranchCurrentCacheDir(name), setupDir, `branch-${name}-old`);
+		const allFiles = glob.sync(`${cacheDir}/**/*.*`);
+		branches[name].cacheDirs = [cacheDir];
+		branches[name].files = allFiles;
 
-			const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
-			branches[name].version = parseInt(
-				sha256(fileHashes.join(" ") + branches[name].main + branches[name].preload + dcVersion).substring(0, 2),
-				16,
-			);
-		} catch (error) {
-			rmSync(setupDir, { recursive: true, force: true });
-			throw error;
-		}
-	});
+		const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
+		branches[name].version = parseInt(
+			sha256(fileHashes.join(" ") + branches[name].main + branches[name].preload + dcVersion).substring(0, 2),
+			16,
+		);
+	} catch (error) {
+		rmSync(setupDir, { recursive: true, force: true });
+		throw error;
+	}
+};
 
 const runBranchSetups = withSection("periodic branch setups", async () => {
 	const names = Object.entries(branches)

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -54,6 +54,8 @@ export const config = Object.freeze({
 	port: rawCfg?.port || DEFAULT_PORT,
 	host: rawCfg?.host || `http://localhost:${rawCfg?.port || DEFAULT_PORT}`,
 	setupIntervalHours: rawCfg?.setupIntervalHours ?? 3,
+	branchRetryMinSeconds: rawCfg?.branchRetryMinSeconds ?? 30,
+	branchRetryMaxSeconds: rawCfg?.branchRetryMaxSeconds ?? 60 * 60,
 	cloudflared: {
 		enabled: !!rawCfg?.cloudflared?.enabled,
 		binary: rawCfg?.cloudflared?.binary || "cloudflared",

--- a/src/dashboard/branches.html
+++ b/src/dashboard/branches.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<title>sheltupdate__VERSION__</title>
+
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+
+		<link rel="stylesheet" href="./dashboard.css" />
+
+		<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital@0;1&display=swap" rel="stylesheet" />
+
+		<link rel="stylesheet" href="https://esm.sh/@unocss/reset@66.7.0/normalize.css" />
+	</head>
+
+	<body>
+		__STAGING_MARQUEE__
+		<div id="header-wrap">
+			<h1>sheltupdate__VERSION__</h1>
+
+			<div id="header-links">
+				<a href="./">Dashboard</a>
+				<a href="sheltupdate_changelog">Changelog</a>
+				<a href="branches" aria-current="page">Branches</a>
+			</div>
+		</div>
+
+		<div id="branches-layout">
+			<div class="stats-card branch-status-card">
+				<h2 class="card-title">Branch Status</h2>
+				__NOTICE__
+			</div>
+
+			<div class="branch-list">__BRANCHES__</div>
+		</div>
+	</body>
+</html>

--- a/src/dashboard/branches.html
+++ b/src/dashboard/branches.html
@@ -29,12 +29,7 @@
 		</div>
 
 		<div id="branches-layout">
-			<div class="stats-card branch-status-card">
-				<h2 class="card-title">Branch Status</h2>
-				__NOTICE__
-			</div>
-
-			<div class="branch-list">__BRANCHES__</div>
+			__BRANCHES__
 		</div>
 	</body>
 </html>

--- a/src/dashboard/branchesPage.js
+++ b/src/dashboard/branchesPage.js
@@ -1,0 +1,46 @@
+import { readFileSync } from "fs";
+
+const template = readFileSync(new URL("./branches.html", import.meta.url), "utf8");
+const escape = (value) =>
+	String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
+const relativeTime = new Intl.RelativeTimeFormat("en", { numeric: "always" });
+const formatRetry = (retryAt) => {
+	const seconds = Math.max(0, Math.ceil((retryAt - Date.now()) / 1_000));
+	if (seconds < 60) return relativeTime.format(seconds, "second");
+	if (seconds < 3_600) return relativeTime.format(Math.ceil(seconds / 60), "minute");
+	if (seconds < 86_400) return relativeTime.format(Math.ceil(seconds / 3_600), "hour");
+	return relativeTime.format(Math.ceil(seconds / 86_400), "day");
+};
+
+export function renderBranchesPage(branches, version, marquee = "") {
+	const failed = branches.filter((branch) => !branch.enabled);
+	const notice = failed.length
+		? `<div class="branch-status" role="alert"><span class="cluster-node cluster-offline" aria-hidden="true"></span>${failed.length} branch${failed.length === 1 ? " is" : "es are"} unavailable</div>`
+		: `<div class="branch-status"><span class="cluster-node cluster-online" aria-hidden="true"></span>All branches available</div>`;
+
+	const cards = branches
+		.map((branch) => {
+			const status = branch.enabled ? "online" : "offline";
+			const retryAt = branch.retryAt && new Date(branch.retryAt);
+			const retry = branch.enabled
+				? ""
+				: `<div class="branch-retry">${
+						retryAt
+							? `<time datetime="${retryAt.toISOString()}">Retrying ${formatRetry(retryAt)}</time>`
+							: "pending"
+					}</div>`;
+
+			return `<article class="stats-card branch-card">
+				<h2 class="card-title">${escape(branch.displayName)}</h2>
+				<div class="branch-status"><span class="cluster-node cluster-${status}" aria-hidden="true"></span>${branch.enabled ? "Available" : "Unavailable"}</div>
+				${retry}
+			</article>`;
+		})
+		.join("");
+
+	return template
+		.replaceAll("__VERSION__", version ? ` r${escape(version)}` : "")
+		.replace("__STAGING_MARQUEE__", marquee)
+		.replace("__NOTICE__", notice)
+		.replace("__BRANCHES__", cards);
+}

--- a/src/dashboard/branchesPage.js
+++ b/src/dashboard/branchesPage.js
@@ -6,41 +6,44 @@ const escape = (value) =>
 const relativeTime = new Intl.RelativeTimeFormat("en", { numeric: "always" });
 const formatRetry = (retryAt) => {
 	const seconds = Math.max(0, Math.ceil((retryAt - Date.now()) / 1_000));
-	if (seconds < 60) return relativeTime.format(seconds, "second");
-	if (seconds < 3_600) return relativeTime.format(Math.ceil(seconds / 60), "minute");
-	if (seconds < 86_400) return relativeTime.format(Math.ceil(seconds / 3_600), "hour");
-	return relativeTime.format(Math.ceil(seconds / 86_400), "day");
+	if (seconds < 60) {
+		const value = seconds;
+		return relativeTime.format(value, value === 1 ? "second" : "seconds");
+	}
+	if (seconds < 3_600) {
+		const value = Math.ceil(seconds / 60);
+		return relativeTime.format(value, value === 1 ? "minute" : "minutes");
+	}
+	if (seconds < 86_400) {
+		const value = Math.ceil(seconds / 3_600);
+		return relativeTime.format(value, value === 1 ? "hour" : "hours");
+	}
+	const value = Math.ceil(seconds / 86_400);
+	return relativeTime.format(value, value === 1 ? "day" : "days");
 };
 
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+
+function branchStatusTemplate(branches) {
+	return `
+	<div id="branch-statuses" class="stats-card">
+		<h2 class="card-title">Branches</h2>
+		<div>
+			${branches.filter(branch => !branch.hidden).map(
+				(branch) => `
+				<div>
+					<div class="branch-status branch-${branch.enabled ? "online" : "offline"}"></div>
+					<span>${branch.displayName}: ${branch.enabled ? "available" : `temporarily unavailable; retrying in ${formatRetry(branch.retryAt)}`}</span>
+					<p class="sub muted">${capitalize(branch.type)}: ${branch.description}</p>
+				</div>`,)
+			.join("\n")}
+		</div>
+	</div>`;
+}
+
 export function renderBranchesPage(branches, version, marquee = "") {
-	const failed = branches.filter((branch) => !branch.enabled);
-	const notice = failed.length
-		? `<div class="branch-status" role="alert"><span class="cluster-node cluster-offline" aria-hidden="true"></span>${failed.length} branch${failed.length === 1 ? " is" : "es are"} unavailable</div>`
-		: `<div class="branch-status"><span class="cluster-node cluster-online" aria-hidden="true"></span>All branches available</div>`;
-
-	const cards = branches
-		.map((branch) => {
-			const status = branch.enabled ? "online" : "offline";
-			const retryAt = branch.retryAt && new Date(branch.retryAt);
-			const retry = branch.enabled
-				? ""
-				: `<div class="branch-retry">${
-						retryAt
-							? `<time datetime="${retryAt.toISOString()}">Retrying ${formatRetry(retryAt)}</time>`
-							: "pending"
-					}</div>`;
-
-			return `<article class="stats-card branch-card">
-				<h2 class="card-title">${escape(branch.displayName)}</h2>
-				<div class="branch-status"><span class="cluster-node cluster-${status}" aria-hidden="true"></span>${branch.enabled ? "Available" : "Unavailable"}</div>
-				${retry}
-			</article>`;
-		})
-		.join("");
-
 	return template
 		.replaceAll("__VERSION__", version ? ` r${escape(version)}` : "")
 		.replace("__STAGING_MARQUEE__", marquee)
-		.replace("__NOTICE__", notice)
-		.replace("__BRANCHES__", cards);
+		.replace("__BRANCHES__", branchStatusTemplate(branches));
 }

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -204,3 +204,31 @@ h1, h2 { font-weight: normal; }
 figure {
 	margin: 0;
 }
+
+#branches-layout {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+	margin-top: 2rem;
+}
+
+.branch-status {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+}
+
+.branch-list {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+	gap: 1.25rem;
+}
+
+.branch-card {
+	min-height: 4rem;
+}
+
+.branch-retry {
+	font-size: 0.8rem;
+	opacity: 0.75;
+}

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -176,19 +176,32 @@ body {
 	}
 }
 
-.cluster-node {
+#branch-statuses {
+	margin-top: 1.25rem;
+
+	& > div {
+		display: flex;
+		flex-flow: column wrap;
+		gap: 1rem;
+		justify-content: space-evenly;
+		align-items: left;
+		width: 100%;
+	}
+}
+
+.cluster-node, .branch-status {
 	display: inline-block;
 	height: 0.8em;
 	width: 0.8em;
 	border-radius: 100%;
 	background: var(--dot-color);
-	&.cluster-live, &.cluster-online {
+	&.cluster-live, &.cluster-online, &.branch-online {
 		--dot-color: #1b9e77;
 	}
-	&.cluster-offline {
+	&.cluster-offline, &.branch-offline {
 		--dot-color: #d22d39;
 	}
-	&.cluster-unknown {
+	&.cluster-unknown, &.branch-unknown {
 		--dot-color: #666666;
 	}
 }
@@ -212,23 +225,6 @@ figure {
 	margin-top: 2rem;
 }
 
-.branch-status {
-	display: flex;
-	align-items: center;
-	gap: 0.75rem;
-}
-
-.branch-list {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-	gap: 1.25rem;
-}
-
-.branch-card {
-	min-height: 4rem;
-}
-
-.branch-retry {
-	font-size: 0.8rem;
-	opacity: 0.75;
+.muted {
+	color: #cccccc;
 }

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -4,6 +4,7 @@ import { config, srcDir, startTime, version } from "../common/config.js";
 import { getSingleBranchMetas } from "../common/branchesLoader.js";
 import { Hono } from "hono";
 import { clusterStartTime, getAggregatedStatistics, getClusterHealth } from "../discovery.js";
+import { renderBranchesPage } from "./branchesPage.js";
 
 const html = readFileSync(join(srcDir, "dashboard", "template.html"), "utf8");
 const css_ = readFileSync(join(srcDir, "dashboard", "dashboard.css"), "utf8");
@@ -52,6 +53,9 @@ function template(temp) {
 
 export default new Hono()
 	.get("/", (c) => c.html(template(html)))
+	.get("/branches", (c) =>
+		c.html(renderBranchesPage(getSingleBranchMetas(), version, isRelease ? "" : stagingMarquee)),
+	)
 	.get("/dashboard.css", (c) => {
 		c.header("Content-Type", "text/css");
 		return c.body(template(css_));

--- a/src/dashboard/template.html
+++ b/src/dashboard/template.html
@@ -36,7 +36,7 @@
 			<div id="header-links">
 				<a href="https://shelter.uwu.network/install">Install</a>
 				<a href="sheltupdate_changelog">Changelog</a>
-				<a href="sheltupdate_branches">Branches</a>
+				<a href="branches">Branches</a>
 			</div>
 		</div>
 


### PR DESCRIPTION
Make branch failures not crash the entire server. Branches are now reported as available or unavailable, shown both in the frontend (new `/branches` path) and the client mods page in the client, so users are not completely blind to this and can report it if we don't notice first (not that they'd check the client mods page, i wanted to add the badge in the settings but i need to fix shelter-ui because obviously that has broken too)

Implements configurable exponential backoff with min/max retry time. Keeps serving cached copies of the branch until the retry time hits the maximum.

To be determined if this state should be synced in the cluster/possibly allowing fetching copies of a failed branch from another node? I think it's unnecessary and reusing the cache for as long as possible is an acceptable tradeoff.